### PR TITLE
Guard AsyncHTTPClient support on the trait instead of canImport

### DIFF
--- a/Sources/EventSource/EventSource+AsyncHTTPClient.swift
+++ b/Sources/EventSource/EventSource+AsyncHTTPClient.swift
@@ -1,4 +1,4 @@
-#if canImport(AsyncHTTPClient)
+#if AsyncHTTPClient
     import AsyncHTTPClient
     import Foundation
     import NIOCore

--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -377,7 +377,7 @@ public actor EventSource {
         private var linuxCompletion: CheckedContinuation<Void, Never>?
         private var linuxCompletionError: Error?
 
-        #if canImport(AsyncHTTPClient)
+        #if AsyncHTTPClient
             private var useAsyncHTTPClientOnLinux = false
         #endif
     #endif
@@ -556,7 +556,7 @@ public actor EventSource {
 
                 // Perform the HTTP request with streaming support
                 #if canImport(FoundationNetworking)
-                    #if canImport(AsyncHTTPClient)
+                    #if AsyncHTTPClient
                         if shouldUseAsyncHTTPClientOnLinux() {
                             try await connectUsingAsyncHTTPClient(
                                 request: currentRequest,
@@ -701,14 +701,14 @@ public actor EventSource {
         }
 
         private func shouldUseAsyncHTTPClientOnLinux() -> Bool {
-            #if canImport(AsyncHTTPClient)
+            #if AsyncHTTPClient
                 return useAsyncHTTPClientOnLinux
             #else
                 return false
             #endif
         }
 
-        #if canImport(AsyncHTTPClient)
+        #if AsyncHTTPClient
             private func shouldFallbackToAsyncHTTPClient(for error: Error) -> Bool {
                 EventSourceFallbackPolicy.shouldFallback(
                     useAsyncHTTPClientOnLinux: useAsyncHTTPClientOnLinux,

--- a/Tests/EventSourceTests/AsyncHTTPClientTraitTests.swift
+++ b/Tests/EventSourceTests/AsyncHTTPClientTraitTests.swift
@@ -1,4 +1,4 @@
-#if canImport(AsyncHTTPClient)
+#if AsyncHTTPClient
     import AsyncHTTPClient
     import Foundation
     import NIOCore


### PR DESCRIPTION
`Package.swift` gates the AsyncHTTPClient dependency on the trait:

```swift
.product(
    name: "AsyncHTTPClient",
    package: "async-http-client",
    condition: .when(traits: ["AsyncHTTPClient"])
)
```

The source gates it on `#if canImport(AsyncHTTPClient)`. The two conditions come apart in a multi-package graph: `canImport` succeeds whenever the module sits on the search path, which happens as soon as any other package in the graph depends on async-http-client, trait or no trait. EventSource then compiles code against a dependency SwiftPM never wired up for this target, and the build dies on a module it cannot see:

```
[10/14] Emitting module EventSource
<unknown>:0: error: missing required module '_NumericsShims'
```

`_NumericsShims` arrives through AsyncHTTPClient → swift-numerics.

### Reproducing

Any package depending on both EventSource and async-http-client hits this with the trait off. I reached it through `modelcontextprotocol/swift-sdk`, which depends on EventSource unconditionally on Apple platforms while my own package depends on AsyncHTTPClient. The workaround today is redeclaring eventsource at the root with `traits: ["AsyncHTTPClient"]`, for a transitive dependency I never import.

### What changed

The five source guards and the test guard now read `#if AsyncHTTPClient`, the compilation condition SwiftPM defines for an enabled trait. You can see it as `-DAsyncHTTPClient` in the build manifest when the trait is on.