### PR TITLE
Gate the NIOCore dependency on the AsyncHTTPClient trait

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,11 @@ let package = Package(
                     package: "async-http-client",
                     condition: .when(traits: ["AsyncHTTPClient"])
                 ),
-                .product(name: "NIOCore", package: "swift-nio"),
+                .product(
+                    name: "NIOCore",
+                    package: "swift-nio",
+                    condition: .when(traits: ["AsyncHTTPClient"])
+                ),
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Follow-up to #18 and #19.

The explicit `swift-nio` dependency from #18 works around the Xcode 26 transitive-dylib linking bug, which can only manifest when AsyncHTTPClient is actually linked — i.e. with the trait enabled. Since #19 moved the source guards to `#if AsyncHTTPClient`, no code references NIO symbols with the trait off, yet `NIOCore` (and its atomics/collections tail) was still compiled into every default-trait consumer's build.

This applies the same `condition: .when(traits: ["AsyncHTTPClient"])` that the `AsyncHTTPClient` product already carries. With the trait disabled, SwiftPM then prunes both dependencies from resolution entirely — no fetch, no compile; with it enabled, nothing changes and #18's workaround stays fully in effect.

Verified both states on macOS:

- `swift test` (default traits): 73 tests pass, `.build/checkouts` is empty — neither swift-nio nor async-http-client is fetched.
- `swift test --traits AsyncHTTPClient`: 81 tests pass, NIO linked as before.

Real-world effect: in a downstream package consuming EventSource through the MCP swift-sdk, a clean build dropped from 30.2 s to 14.4 s (16 modules gone).